### PR TITLE
Add infra.cache.count and key.cache.count metrics

### DIFF
--- a/unbound_exporter.go
+++ b/unbound_exporter.go
@@ -258,6 +258,18 @@ var (
 			prometheus.GaugeValue,
 			nil,
 			"^rrset\\.cache\\.count$"),
+		newUnboundMetric(
+			"infra_cache_count",
+			"The number of items in the infra cache",
+			prometheus.GaugeValue,
+			nil,
+			"^infra\\.cache\\.count$"),
+		newUnboundMetric(
+			"key_cache_count",
+			"The number of items in the key cache",
+			prometheus.GaugeValue,
+			nil,
+			"^key\\.cache\\.count$"),
 	}
 )
 


### PR DESCRIPTION
This allows us to measure the infra cache and key cache functionality.